### PR TITLE
feat: add utilities and validators

### DIFF
--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -1,0 +1,67 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+
+const COOKIE_NAME = 'admin_session';
+const secret = process.env.SESSION_SECRET;
+if (!secret) {
+  throw new Error('SESSION_SECRET missing');
+}
+
+export interface AdminSession {
+  email: string;
+}
+
+function sign(payload: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+export function setAdminSessionCookie(
+  res: NextResponse,
+  session: AdminSession,
+): void {
+  const payload = JSON.stringify(session);
+  const signature = sign(payload);
+  const value = Buffer.from(`${payload}.${signature}`).toString('base64');
+
+  res.cookies.set(COOKIE_NAME, value, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 60 * 60 * 24 * 30,
+    path: '/',
+  });
+}
+
+export function readAdminSessionCookie(
+  req: NextRequest,
+): AdminSession | null {
+  const raw = req.cookies.get(COOKIE_NAME)?.value;
+  if (!raw) return null;
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8');
+    const [payload, signature] = decoded.split('.');
+    if (!payload || !signature) return null;
+    const expected = sign(payload);
+    const sigBuf = Buffer.from(signature, 'hex');
+    const expBuf = Buffer.from(expected, 'hex');
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+      return null;
+    }
+    const data = JSON.parse(payload);
+    if (typeof data.email !== 'string') return null;
+    return { email: data.email };
+  } catch {
+    return null;
+  }
+}
+
+export function clearAdminSessionCookie(res: NextResponse): void {
+  res.cookies.set(COOKIE_NAME, '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+    path: '/',
+  });
+}
+

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,0 +1,17 @@
+import { createHash, randomBytes } from 'crypto';
+
+const salt = process.env.CRYPTO_TOKEN_SALT;
+if (!salt) {
+  throw new Error('CRYPTO_TOKEN_SALT missing');
+}
+
+export function hashToken(token: string): string {
+  const hash = createHash('sha256');
+  hash.update(salt + token);
+  return `sha256:${hash.digest('hex')}`;
+}
+
+export function generateToken(bytes = 32): string {
+  return randomBytes(bytes).toString('hex');
+}
+

--- a/lib/utils/csv.ts
+++ b/lib/utils/csv.ts
@@ -1,0 +1,28 @@
+function escapeCsv(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return '"' + value.replace(/"/g, '""') + '"';
+  }
+  return value;
+}
+
+export interface CsvColumn<T> {
+  key: keyof T;
+  header: string;
+}
+
+export function exportToCsv<T extends Record<string, any>>(
+  rows: T[],
+  columns: CsvColumn<T>[],
+): string {
+  const headerLine = columns.map((c) => escapeCsv(String(c.header))).join(',');
+  const lines = rows.map((row) =>
+    columns
+      .map((c) => {
+        const val = row[c.key] ?? '';
+        return escapeCsv(String(val));
+      })
+      .join(','),
+  );
+  return '\uFEFF' + [headerLine, ...lines].join('\r\n');
+}
+

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -1,0 +1,31 @@
+export function normalizeDate(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function parseYearMonth(str: string): { year: number; month: number } | null {
+  const match = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(str);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return { year, month };
+}
+
+export function parseYyyymm(str: string): { year: number; month: number } | null {
+  const match = /^(\d{4})(0[1-9]|1[0-2])$/.exec(str);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return { year, month };
+}
+
+export function isDateInMonth(date: Date, year: number, month: number): boolean {
+  const d = normalizeDate(date);
+  return d.getFullYear() === year && d.getMonth() + 1 === month;
+}
+
+export function toYyyymm(year: number, month: number): string {
+  return `${year}${String(month).padStart(2, '0')}`;
+}
+

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+const planRegex = /^(\d{4})-(0[1-9]|1[0-2])$/;
+const planCompactRegex = /^(\d{4})(0[1-9]|1[0-2])$/;
+
+export const PlanQuerySchema = z.object({
+  plan: z.string().regex(planRegex),
+  g: z.string(),
+  t: z.string(),
+});
+
+export const PlanQueryCompactSchema = z.object({
+  plan: z.string().regex(planCompactRegex),
+  g: z.string(),
+  t: z.string(),
+});
+
+export const AssignmentRowSchema = z.object({
+  date: z.string().datetime(),
+  address: z.string().min(1),
+  notes: z.string().optional(),
+});
+
+export const BulkUpsertSchema = z.object({
+  plan: z.string().regex(planRegex),
+  g: z.string(),
+  t: z.string(),
+  rows: z.array(AssignmentRowSchema),
+});
+
+export const SubmitSchema = z.object({
+  plan: z.string().regex(planRegex),
+  g: z.string(),
+  t: z.string(),
+});
+
+export const AdminAuthSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+


### PR DESCRIPTION
## Summary
- add token hashing and generator
- implement signed admin session cookie helpers
- provide date normalization, parsing, and CSV export utilities
- define core Zod schemas for plans, assignments, bulk upserts, submissions, and admin auth

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b04d6df04c832996c96cc5cd86083e