### PR TITLE
feat: add api layer and ui foundation

### DIFF
--- a/app/api/admin/init/route.ts
+++ b/app/api/admin/init/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
     .collection('assignments')
     .createIndex({ plan_id: 1, gardener_id: 1, work_date: 1, address: 1 }, { unique: true });
   await db.collection('submissions').createIndex({ plan_id: 1, gardener_id: 1 }, { unique: true });
+  await db.collection('ratelimits').createIndex({ created_at: 1 }, { expireAfterSeconds: 60 * 10 });
 
   const gardenersCol = db.collection<Gardener>('gardeners');
   if ((await gardenersCol.countDocuments()) === 0) {

--- a/app/api/admin/links/create/route.ts
+++ b/app/api/admin/links/create/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanParamSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminSessionCookie } from '@/lib/cookies';
+import { listGardeners } from '@/lib/repositories/gardeners';
+import { createOrUpdateLinksForPlan } from '@/lib/repositories/planLinks';
+import { createPlanIfMissing } from '@/lib/repositories/plans';
+
+export async function POST(req: NextRequest) {
+  const session = readAdminSessionCookie(req);
+  if (!session) {
+    return jsonError('unauthorized', 'Unauthorized', 401);
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = PlanParamSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError('invalid_body', 'Invalid request body', 400);
+  }
+  const { plan } = parsed.data;
+  const year = Number(plan.slice(0, 4));
+  const month = Number(plan.slice(5, 7));
+  const planDoc = await createPlanIfMissing(year, month);
+  const gardeners = await listGardeners();
+  const tokens = await createOrUpdateLinksForPlan(
+    planDoc._id,
+    gardeners.map((g) => g._id),
+  );
+  return NextResponse.json({ tokens });
+}

--- a/app/api/admin/lock/route.ts
+++ b/app/api/admin/lock/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanParamSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminSessionCookie } from '@/lib/cookies';
+import { getPlanByYyyymm, toggleLock } from '@/lib/repositories/plans';
+
+export async function POST(req: NextRequest) {
+  const session = readAdminSessionCookie(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  const body = await req.json().catch(() => null);
+  const parsed = PlanParamSchema.safeParse(body);
+  if (!parsed.success) return jsonError('invalid_body', 'Invalid request body', 400);
+  const yyyymm = parsed.data.plan.replace('-', '');
+  const plan = await getPlanByYyyymm(yyyymm);
+  if (!plan) return jsonError('not_found', 'Plan not found', 404);
+  await toggleLock(plan._id, true);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AdminAuthSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { setAdminSessionCookie } from '@/lib/cookies';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const parsed = AdminAuthSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError('invalid_body', 'Invalid credentials', 400);
+  }
+  const { email, password } = parsed.data;
+  if (
+    email !== process.env.NEXT_ADMIN_EMAIL ||
+    password !== process.env.NEXT_ADMIN_PASSWORD
+  ) {
+    return jsonError('unauthorized', 'Invalid credentials', 401);
+  }
+  const res = NextResponse.json({ ok: true });
+  setAdminSessionCookie(res, { email });
+  return res;
+}

--- a/app/api/admin/overview/route.ts
+++ b/app/api/admin/overview/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanParamSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminSessionCookie } from '@/lib/cookies';
+import { getPlanByYyyymm } from '@/lib/repositories/plans';
+import { listGardeners } from '@/lib/repositories/gardeners';
+import { getDb } from '@/lib/mongo';
+import { exportToCsv } from '@/lib/utils/csv';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = readAdminSessionCookie(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  const url = new URL(req.url);
+  const params = Object.fromEntries(url.searchParams.entries());
+  const parsed = PlanParamSchema.safeParse(params);
+  if (!parsed.success) return jsonError('invalid_query', 'Invalid query', 400);
+  const { plan } = parsed.data;
+  const format = url.searchParams.get('format');
+  const yyyymm = plan.replace('-', '');
+  const planDoc = await getPlanByYyyymm(yyyymm);
+  if (!planDoc) return jsonError('not_found', 'Plan not found', 404);
+  const gardeners = await listGardeners();
+  const gardenerMap = new Map(gardeners.map((g) => [g._id.toString(), g.name]));
+  const db = await getDb();
+  const assignments = await db
+    .collection('assignments')
+    .find({ plan_id: planDoc._id })
+    .toArray();
+  const submissions = await db
+    .collection('submissions')
+    .countDocuments({ plan_id: planDoc._id });
+  const coverageDays = new Set(
+    assignments.map((a) => a.work_date.toISOString().slice(0, 10)),
+  ).size;
+  const rows = assignments.map((a) => ({
+    date: a.work_date.toISOString().slice(0, 10),
+    gardener: gardenerMap.get(a.gardener_id.toString()) || '',
+    address: a.address,
+    notes: a.notes || '',
+  }));
+  if (format === 'csv') {
+    const csv = exportToCsv(rows, [
+      { key: 'date', header: 'תאריך' },
+      { key: 'gardener', header: 'גנן' },
+      { key: 'address', header: 'כתובת' },
+      { key: 'notes', header: 'הערות' },
+    ]);
+    return new NextResponse(csv, {
+      headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+    });
+  }
+  return NextResponse.json({
+    stats: {
+      gardeners: gardeners.length,
+      submitted: submissions,
+      assignments: assignments.length,
+      coverageDays,
+    },
+    rows,
+  });
+}

--- a/app/api/admin/remind/route.ts
+++ b/app/api/admin/remind/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readAdminSessionCookie } from '@/lib/cookies';
+import { jsonError } from '@/lib/api';
+
+export async function POST(req: NextRequest) {
+  const session = readAdminSessionCookie(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  console.log('Reminder requested by', session.email);
+  return NextResponse.json({ ok: true }, { status: 202 });
+}

--- a/app/api/admin/unlock/route.ts
+++ b/app/api/admin/unlock/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanParamSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminSessionCookie } from '@/lib/cookies';
+import { getPlanByYyyymm, toggleLock } from '@/lib/repositories/plans';
+
+export async function POST(req: NextRequest) {
+  const session = readAdminSessionCookie(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  const body = await req.json().catch(() => null);
+  const parsed = PlanParamSchema.safeParse(body);
+  if (!parsed.success) return jsonError('invalid_body', 'Invalid request body', 400);
+  const yyyymm = parsed.data.plan.replace('-', '');
+  const plan = await getPlanByYyyymm(yyyymm);
+  if (!plan) return jsonError('not_found', 'Plan not found', 404);
+  await toggleLock(plan._id, false);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/assignments/[id]/route.ts
+++ b/app/api/assignments/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanQuerySchema } from '@/lib/validators';
+import { jsonError, getIp, verifyLink } from '@/lib/api';
+import { checkRateLimit } from '@/lib/rateLimit';
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/mongo';
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const query = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = PlanQuerySchema.safeParse(query);
+  if (!parsed.success) {
+    return jsonError('invalid_query', 'Invalid query parameters', 400);
+  }
+  const { plan, g, t } = parsed.data;
+  const key = `${getIp(req)}:assignment-delete`;
+  if (!(await checkRateLimit(key))) {
+    return jsonError('rate_limit', 'Too many requests', 429);
+  }
+  const auth = await verifyLink(plan, g, t);
+  if ('status' in auth) {
+    return jsonError(auth.code, auth.message, auth.status);
+  }
+  let id: ObjectId;
+  try {
+    id = new ObjectId(params.id);
+  } catch {
+    return jsonError('invalid_id', 'Invalid id', 400);
+  }
+  const db = await getDb();
+  const res = await db
+    .collection('assignments')
+    .deleteOne({ _id: id, plan_id: auth.plan._id, gardener_id: auth.gardenerId });
+  if (res.deletedCount === 0) {
+    return jsonError('not_found', 'Assignment not found', 404);
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/assignments/route.ts
+++ b/app/api/assignments/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanQuerySchema, BulkUpsertSchema } from '@/lib/validators';
+import { jsonError, getIp, verifyLink } from '@/lib/api';
+import { checkRateLimit } from '@/lib/rateLimit';
+import { listByPlanAndGardener, bulkUpsert } from '@/lib/repositories/assignments';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const params = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = PlanQuerySchema.safeParse(params);
+  if (!parsed.success) {
+    return jsonError('invalid_query', 'Invalid query parameters', 400);
+  }
+  const { plan, g, t } = parsed.data;
+  const key = `${getIp(req)}:assignments-get`;
+  if (!(await checkRateLimit(key))) {
+    return jsonError('rate_limit', 'Too many requests', 429);
+  }
+  const auth = await verifyLink(plan, g, t);
+  if ('status' in auth) {
+    return jsonError(auth.code, auth.message, auth.status);
+  }
+  const rows = await listByPlanAndGardener(auth.plan._id, auth.gardenerId);
+  return NextResponse.json({
+    assignments: rows.map((r) => ({
+      id: r._id.toString(),
+      date: r.work_date.toISOString(),
+      address: r.address,
+      notes: r.notes || null,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const parsed = BulkUpsertSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError('invalid_body', 'Invalid request body', 400);
+  }
+  const { plan, g, t, rows } = parsed.data;
+  const key = `${getIp(req)}:assignments-post`;
+  if (!(await checkRateLimit(key))) {
+    return jsonError('rate_limit', 'Too many requests', 429);
+  }
+  const auth = await verifyLink(plan, g, t);
+  if ('status' in auth) {
+    return jsonError(auth.code, auth.message, auth.status);
+  }
+  const norm = rows.map((r) => {
+    const d = new Date(r.date);
+    d.setHours(0, 0, 0, 0);
+    return { work_date: d, address: r.address, notes: r.notes };
+  });
+  const res = await bulkUpsert(auth.plan._id, auth.gardenerId, norm);
+  return NextResponse.json(res);
+}

--- a/app/api/link/resolve/route.ts
+++ b/app/api/link/resolve/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PlanQuerySchema } from '@/lib/validators';
+import { checkRateLimit } from '@/lib/rateLimit';
+import { getIp, jsonError, verifyLink } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const params = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = PlanQuerySchema.safeParse(params);
+  if (!parsed.success) {
+    return jsonError('invalid_query', 'Invalid query parameters', 400);
+  }
+  const { plan, g, t } = parsed.data;
+  const key = `${getIp(req)}:link-resolve`;
+  if (!(await checkRateLimit(key))) {
+    return jsonError('rate_limit', 'Too many requests', 429);
+  }
+  const auth = await verifyLink(plan, g, t);
+  if ('status' in auth) {
+    return jsonError(auth.code, auth.message, auth.status);
+  }
+  return NextResponse.json({
+    plan: { id: auth.plan._id.toString(), year: auth.plan.year, month: auth.plan.month, locked: auth.plan.locked },
+    gardener: { id: auth.gardener._id.toString(), name: auth.gardener.name },
+    submission: auth.submission ? { submitted_at: auth.submission.submitted_at } : null,
+  });
+}

--- a/app/api/submission/revert/route.ts
+++ b/app/api/submission/revert/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SubmitSchema } from '@/lib/validators';
+import { jsonError, getIp, verifyLink } from '@/lib/api';
+import { checkRateLimit } from '@/lib/rateLimit';
+import { revert } from '@/lib/repositories/submissions';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const parsed = SubmitSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError('invalid_body', 'Invalid request body', 400);
+  }
+  const { plan, g, t } = parsed.data;
+  const key = `${getIp(req)}:revert`;
+  if (!(await checkRateLimit(key))) {
+    return jsonError('rate_limit', 'Too many requests', 429);
+  }
+  const auth = await verifyLink(plan, g, t);
+  if ('status' in auth) {
+    return jsonError(auth.code, auth.message, auth.status);
+  }
+  if (auth.plan.locked) {
+    return jsonError('locked', 'Plan is locked', 400);
+  }
+  await revert(auth.plan._id, auth.gardenerId);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/submission/submit/route.ts
+++ b/app/api/submission/submit/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SubmitSchema } from '@/lib/validators';
+import { jsonError, getIp, verifyLink } from '@/lib/api';
+import { checkRateLimit } from '@/lib/rateLimit';
+import { submit } from '@/lib/repositories/submissions';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const parsed = SubmitSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError('invalid_body', 'Invalid request body', 400);
+  }
+  const { plan, g, t } = parsed.data;
+  const key = `${getIp(req)}:submit`;
+  if (!(await checkRateLimit(key))) {
+    return jsonError('rate_limit', 'Too many requests', 429);
+  }
+  const auth = await verifyLink(plan, g, t);
+  if ('status' in auth) {
+    return jsonError(auth.code, auth.message, auth.status);
+  }
+  if (auth.plan.locked) {
+    return jsonError('locked', 'Plan is locked', 400);
+  }
+  await submit(auth.plan._id, auth.gardenerId);
+  return NextResponse.json({ ok: true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,25 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 47.4% 11.2%;
+    --border: 214.3 31.8% 91.4%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,22 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { Alef } from 'next/font/google';
+import { Toaster } from '@/components/ui/toaster';
+import { cn } from '@/lib/utils';
+
+const font = Alef({ subsets: ['hebrew'], weight: ['400', '700'], variable: '--font-sans' });
+
+export const metadata = {
+  title: 'Amit Gardens',
+  viewport: { width: 'device-width', initialScale: 1 },
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" dir="ltr">
-      <body className="min-h-screen">{children}</body>
+    <html lang="he" dir="rtl">
+      <body className={cn('min-h-screen bg-background font-sans antialiased', font.variable)}>
+        <Toaster>{children}</Toaster>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from 'next/navigation';
+
 export default function Page() {
-  return <h1 className="text-2xl font-bold">Amit Gardens</h1>;
+  redirect('/admin/login');
 }

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import * as ToastPrimitive from '@radix-ui/react-toast';
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface ToastItem {
+  id: number;
+  title: string;
+  description?: string;
+}
+
+const ToastContext = createContext<
+  (toast: { title: string; description?: string }) => void
+>(() => {});
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+export function Toaster({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const add = (toast: { title: string; description?: string }) => {
+    setToasts((prev) => [...prev, { id: Date.now(), ...toast }]);
+  };
+  const remove = (id: number) =>
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  return (
+    <ToastPrimitive.Provider swipeDirection="right">
+      <ToastContext.Provider value={add}>{children}</ToastContext.Provider>
+      {toasts.map((t) => (
+        <ToastPrimitive.Root
+          key={t.id}
+          open
+          onOpenChange={(open) => !open && remove(t.id)}
+          className="bg-gray-800 text-white rounded-md p-4 mb-2 shadow"
+        >
+          <ToastPrimitive.Title className="font-medium">
+            {t.title}
+          </ToastPrimitive.Title>
+          {t.description && (
+            <ToastPrimitive.Description className="text-sm opacity-80">
+              {t.description}
+            </ToastPrimitive.Description>
+          )}
+        </ToastPrimitive.Root>
+      ))}
+      <ToastPrimitive.Viewport className="fixed bottom-0 left-0 flex flex-col p-4 gap-2 w-96 max-w-[100vw] z-50" />
+    </ToastPrimitive.Provider>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,52 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getPlanByYyyymm } from './repositories/plans';
+import { getGardenerById } from './repositories/gardeners';
+import { resolveLink as resolveLinkRepo } from './repositories/planLinks';
+import { getStatus } from './repositories/submissions';
+import type { Plan, Gardener, Submission } from '@/types/db';
+
+export function jsonError(code: string, message: string, status = 400) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+export function getIp(req: NextRequest): string {
+  return (
+    (req.ip as string | undefined) ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export interface AuthContext {
+  plan: Plan;
+  gardener: Gardener;
+  submission: Submission | null;
+  gardenerId: ObjectId;
+}
+
+export async function verifyLink(
+  planStr: string,
+  g: string,
+  t: string,
+): Promise<AuthContext | { status: number; code: string; message: string }> {
+  const yyyymm = planStr.replace('-', '');
+  const plan = await getPlanByYyyymm(yyyymm);
+  if (!plan)
+    return { status: 404, code: 'not_found', message: 'Plan not found' };
+  let gardenerId: ObjectId;
+  try {
+    gardenerId = new ObjectId(g);
+  } catch {
+    return { status: 400, code: 'invalid_g', message: 'Invalid gardener' };
+  }
+  const gardener = await getGardenerById(gardenerId);
+  if (!gardener)
+    return { status: 404, code: 'not_found', message: 'Gardener not found' };
+  const link = await resolveLinkRepo(plan._id, gardenerId, t);
+  if (!link) return { status: 401, code: 'invalid_token', message: 'Invalid token' };
+  if (link.expires_at && link.expires_at < new Date())
+    return { status: 410, code: 'expired', message: 'Link expired' };
+  const submission = await getStatus(plan._id, gardenerId);
+  return { plan, gardener, submission, gardenerId };
+}

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,17 @@
+import { getDb } from './mongo';
+
+export async function checkRateLimit(
+  key: string,
+  limit = 60,
+  windowMs = 10 * 60 * 1000,
+): Promise<boolean> {
+  const db = await getDb();
+  const col = db.collection<{ key: string; created_at: Date }>('ratelimits');
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowMs);
+  await col.deleteMany({ key, created_at: { $lt: windowStart } });
+  const count = await col.countDocuments({ key, created_at: { $gte: windowStart } });
+  if (count >= limit) return false;
+  await col.insertOne({ key, created_at: now });
+  return true;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,5 @@
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return twMerge(classes.filter(Boolean).join(' '));
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -15,6 +15,10 @@ export const PlanQueryCompactSchema = z.object({
   t: z.string(),
 });
 
+export const PlanParamSchema = z.object({
+  plan: z.string().regex(planRegex),
+});
+
 export const AssignmentRowSchema = z.object({
   date: z.string().datetime(),
   address: z.string().min(1),


### PR DESCRIPTION
## Summary
- implement public and admin API routes with basic rate limiting and validation
- add admin auth, link creation, overview, lock/unlock and submission endpoints
- establish RTL layout, theme variables and toast provider for UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-slot)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e458cf48329b0f5b21badd2cd67