### PR TITLE
Public plan page and admin auth guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/app/(public)/plan/[yyyymm]/page.tsx
+++ b/app/(public)/plan/[yyyymm]/page.tsx
@@ -1,0 +1,20 @@
+import PlanClient from './plan-client';
+
+export default function PlanPage({
+  params,
+  searchParams,
+}: {
+  params: { yyyymm: string };
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const { yyyymm } = params;
+  const g = typeof searchParams.g === 'string' ? searchParams.g : '';
+  const t = typeof searchParams.t === 'string' ? searchParams.t : '';
+  const plan = yyyymm.includes('-')
+    ? yyyymm
+    : `${yyyymm.slice(0, 4)}-${yyyymm.slice(4, 6)}`;
+  if (!g || !t) {
+    return <div className="p-4">קישור לא תקין</div>;
+  }
+  return <PlanClient plan={plan} g={g} t={t} />;
+}

--- a/app/(public)/plan/[yyyymm]/plan-client.tsx
+++ b/app/(public)/plan/[yyyymm]/plan-client.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@/lib/zodResolver';
+import { AssignmentRowSchema } from '@/lib/validators';
+import AssignmentRow, { AssignmentFormRow } from '@/components/AssignmentRow';
+import BulkPasteDialog, { BulkRow } from '@/components/BulkPasteDialog';
+import { useToast } from '@/components/ui/toaster';
+
+const RowSchema = AssignmentRowSchema.extend({ id: z.string().optional() });
+const FormSchema = z.object({ rows: z.array(RowSchema) });
+
+type FormData = z.infer<typeof FormSchema>;
+
+interface Props {
+  plan: string; // YYYY-MM
+  g: string;
+  t: string;
+}
+
+export default function PlanClient({ plan, g, t }: Props) {
+  const toast = useToast();
+  const [info, setInfo] = useState<{
+    gardener: string;
+    locked: boolean;
+    submitted: boolean;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { rows: [] },
+  });
+  const { control, register, handleSubmit, reset } = form;
+  const { fields, append, remove } = useFieldArray({ control, name: 'rows' });
+
+  const readOnly = info?.locked || info?.submitted;
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      setError(null);
+      const res = await fetch(`/api/link/resolve?plan=${plan}&g=${g}&t=${t}`);
+      if (!res.ok) {
+        setError('קישור לא תקין');
+        setLoading(false);
+        return;
+      }
+      const data = await res.json();
+      setInfo({
+        gardener: data.gardener.name,
+        locked: data.plan.locked,
+        submitted: !!data.submission,
+      });
+      const resRows = await fetch(`/api/assignments?plan=${plan}&g=${g}&t=${t}`);
+      if (resRows.ok) {
+        const rows = await resRows.json();
+        reset({
+          rows: rows.assignments.map((r: any) => ({
+            id: r.id,
+            date: r.date.slice(0, 10),
+            address: r.address,
+            notes: r.notes || '',
+          })),
+        });
+      }
+      setLoading(false);
+    }
+    load();
+  }, [plan, g, t, reset]);
+
+  const refreshRows = async () => {
+    const resRows = await fetch(`/api/assignments?plan=${plan}&g=${g}&t=${t}`);
+    if (resRows.ok) {
+      const rows = await resRows.json();
+      reset({
+        rows: rows.assignments.map((r: any) => ({
+          id: r.id,
+          date: r.date.slice(0, 10),
+          address: r.address,
+          notes: r.notes || '',
+        })),
+      });
+    }
+  };
+
+  const onSave = handleSubmit(async (data) => {
+    const body = {
+      plan,
+      g,
+      t,
+      rows: data.rows.map((r) => ({
+        date: new Date(r.date).toISOString(),
+        address: r.address,
+        notes: r.notes,
+      })),
+    };
+    const res = await fetch('/api/assignments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      toast({ title: 'נשמר בהצלחה' });
+      await refreshRows();
+    } else {
+      toast({ title: 'שגיאה בשמירה' });
+    }
+  });
+
+  const onDelete = async (idx: number, id?: string) => {
+    remove(idx);
+    if (id) {
+      await fetch(`/api/assignments/${id}?plan=${plan}&g=${g}&t=${t}`, {
+        method: 'DELETE',
+      });
+      await refreshRows();
+    }
+  };
+
+  const onPaste = (rows: BulkRow[]) => {
+    rows.forEach((r) =>
+      append({ date: r.date, address: r.address, notes: r.notes || '' }),
+    );
+  };
+
+  const submitFinal = async () => {
+    const res = await fetch('/api/submission/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan, g, t }),
+    });
+    if (res.ok) {
+      toast({ title: 'הוגש' });
+      setInfo((prev) => (prev ? { ...prev, submitted: true } : prev));
+    } else {
+      toast({ title: 'שגיאה בשליחה' });
+    }
+  };
+
+  if (loading) return <div className="p-4">טוען…</div>;
+  if (error) return <div className="p-4">{error}</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      {info && (
+        <h1 className="text-xl font-bold text-center">
+          {`שיבוץ לחודש ${plan} – ${info.gardener}`}
+        </h1>
+      )}
+      <form onSubmit={onSave} className="space-y-2">
+        <table className="w-full text-right border">
+          <thead>
+            <tr>
+              <th className="border p-1">תאריך</th>
+              <th className="border p-1">כתובת</th>
+              <th className="border p-1">הערות</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {fields.map((field, idx) => (
+              <AssignmentRow
+                key={field.id}
+                index={idx}
+                control={control}
+                register={register}
+                errors={form.formState.errors}
+                onDelete={() => onDelete(idx, (field as AssignmentFormRow).id)}
+                disabled={readOnly}
+                month={plan}
+              />
+            ))}
+          </tbody>
+        </table>
+        {!readOnly && (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => append({ date: '', address: '', notes: '' })}
+              className="px-2 py-1 border"
+            >
+              הוסף שורה
+            </button>
+            <BulkPasteDialog onConfirm={onPaste} />
+            <button type="submit" className="px-2 py-1 border">
+              שמור
+            </button>
+            <button
+              type="button"
+              onClick={submitFinal}
+              className="px-2 py-1 border"
+            >
+              שליחה סופית
+            </button>
+          </div>
+        )}
+      </form>
+      {readOnly && <p className="text-center">הטופס נעול</p>}
+    </div>
+  );
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@/lib/zodResolver';
+import dayjs from 'dayjs';
+import { AdminAuthSchema } from '@/lib/validators';
+import { useToast } from '@/components/ui/toaster';
+
+type FormData = z.infer<typeof AdminAuthSchema>;
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const toast = useToast();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(AdminAuthSchema) });
+
+  const onSubmit = async (data: FormData) => {
+    setServerError(null);
+    const res = await fetch('/api/admin/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      toast({ title: 'התחברת בהצלחה' });
+      const plan = dayjs().format('YYYY-MM');
+      router.push(`/admin/plan/${plan}`);
+    } else {
+      const json = await res.json().catch(() => null);
+      setServerError(json?.message || 'שגיאה');
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto p-4 space-y-4">
+      <h1 className="text-xl font-bold text-center">התחברות מנהל</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div className="space-y-1">
+          <label htmlFor="email" className="block">
+            אימייל
+          </label>
+          <input
+            id="email"
+            type="email"
+            className="w-full border p-2"
+            {...register('email')}
+            disabled={isSubmitting}
+          />
+          {errors.email && (
+            <p className="text-red-600 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <div className="space-y-1">
+          <label htmlFor="password" className="block">
+            סיסמה
+          </label>
+          <input
+            id="password"
+            type="password"
+            className="w-full border p-2"
+            {...register('password')}
+            disabled={isSubmitting}
+          />
+          {errors.password && (
+            <p className="text-red-600 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+        {serverError && (
+          <p className="text-red-600 text-sm text-center">{serverError}</p>
+        )}
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          התחבר
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/AdminGuard.tsx
+++ b/components/AdminGuard.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { readAdminSessionFromCookie } from '@/lib/cookies';
+
+export default function AdminGuard({ children }: { children: ReactNode }) {
+  const cookie = cookies().get('admin_session')?.value;
+  const session = readAdminSessionFromCookie(cookie);
+  if (!session) {
+    redirect('/admin/login');
+  }
+  return <>{children}</>;
+}

--- a/components/AssignmentRow.tsx
+++ b/components/AssignmentRow.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { FieldErrors, UseFormRegister, Control, Controller } from 'react-hook-form';
+import MonthPicker from './MonthPicker';
+import { z } from 'zod';
+import { AssignmentRowSchema } from '@/lib/validators';
+
+const RowSchema = AssignmentRowSchema.extend({ id: z.string().optional() });
+export type AssignmentFormRow = z.infer<typeof RowSchema>;
+
+type FormType = { rows: AssignmentFormRow[] };
+
+interface Props {
+  index: number;
+  control: Control<FormType>;
+  register: UseFormRegister<FormType>;
+  errors: FieldErrors<FormType>;
+  onDelete: () => void;
+  disabled?: boolean;
+  month: string;
+}
+
+export default function AssignmentRow({
+  index,
+  control,
+  register,
+  errors,
+  onDelete,
+  disabled,
+  month,
+}: Props) {
+  return (
+    <tr>
+      <td className="border p-1">
+        <Controller
+          control={control}
+          name={`rows.${index}.date` as const}
+          render={({ field }) => (
+            <MonthPicker
+              month={month}
+              value={field.value}
+              onChange={field.onChange}
+              disabled={disabled}
+            />
+          )}
+        />
+        {errors.rows?.[index]?.date && (
+          <p className="text-red-600 text-xs">
+            {(errors.rows[index]?.date as any)?.message}
+          </p>
+        )}
+      </td>
+      <td className="border p-1">
+        <input
+          type="text"
+          className="border p-1 w-full"
+          disabled={disabled}
+          {...register(`rows.${index}.address` as const)}
+        />
+        {errors.rows?.[index]?.address && (
+          <p className="text-red-600 text-xs">
+            {(errors.rows[index]?.address as any)?.message}
+          </p>
+        )}
+      </td>
+      <td className="border p-1">
+        <input
+          type="text"
+          className="border p-1 w-full"
+          disabled={disabled}
+          {...register(`rows.${index}.notes` as const)}
+        />
+      </td>
+      <td className="border p-1 text-center">
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={disabled}
+          className="text-red-600"
+        >
+          ✕
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/components/BulkPasteDialog.tsx
+++ b/components/BulkPasteDialog.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface BulkRow {
+  date: string;
+  address: string;
+  notes?: string;
+}
+
+export default function BulkPasteDialog({
+  onConfirm,
+}: {
+  onConfirm: (rows: BulkRow[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+
+  const parse = () => {
+    const rows: BulkRow[] = [];
+    text
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .forEach((line) => {
+        const [date, address, notes] = line.split('|').map((s) => s.trim());
+        if (date && address) {
+          rows.push({ date, address, notes });
+        }
+      });
+    if (rows.length) {
+      onConfirm(rows);
+    }
+    setOpen(false);
+    setText('');
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="px-2 py-1 border"
+      >
+        הדבקה מרשימה
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white p-4 space-y-2 max-w-md w-full">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="w-full h-40 border p-2"
+        />
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            className="px-2 py-1 border"
+            onClick={() => setOpen(false)}
+          >
+            בטל
+          </button>
+          <button type="button" className="px-2 py-1 border" onClick={parse}>
+            אישור
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/MonthPicker.tsx
+++ b/components/MonthPicker.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  month: string; // YYYY-MM
+  disabled?: boolean;
+}
+
+export default function MonthPicker({ value, onChange, month, disabled }: Props) {
+  const [year, m] = month.split('-').map(Number);
+  const first = new Date(year, m - 1, 1).toISOString().slice(0, 10);
+  const last = new Date(year, m, 0).toISOString().slice(0, 10);
+  return (
+    <input
+      type="date"
+      min={first}
+      max={last}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className="border p-1"
+    />
+  );
+}

--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -32,10 +32,7 @@ export function setAdminSessionCookie(
   });
 }
 
-export function readAdminSessionCookie(
-  req: NextRequest,
-): AdminSession | null {
-  const raw = req.cookies.get(COOKIE_NAME)?.value;
+function parseSession(raw: string | undefined): AdminSession | null {
   if (!raw) return null;
   try {
     const decoded = Buffer.from(raw, 'base64').toString('utf8');
@@ -53,6 +50,19 @@ export function readAdminSessionCookie(
   } catch {
     return null;
   }
+}
+
+export function readAdminSessionCookie(
+  req: NextRequest,
+): AdminSession | null {
+  const raw = req.cookies.get(COOKIE_NAME)?.value;
+  return parseSession(raw);
+}
+
+export function readAdminSessionFromCookie(
+  raw: string | undefined,
+): AdminSession | null {
+  return parseSession(raw);
 }
 
 export function clearAdminSessionCookie(res: NextResponse): void {

--- a/lib/zodResolver.ts
+++ b/lib/zodResolver.ts
@@ -1,0 +1,17 @@
+import type { Resolver } from 'react-hook-form';
+import { ZodTypeAny } from 'zod';
+
+export function zodResolver<T extends ZodTypeAny>(schema: T): Resolver {
+  return async (values) => {
+    const result = schema.safeParse(values);
+    if (result.success) {
+      return { values: result.data, errors: {} };
+    }
+    const formErrors: Record<string, any> = {};
+    result.error.errors.forEach((err) => {
+      const path = err.path[0] as string;
+      formErrors[path] = { type: 'validation', message: err.message };
+    });
+    return { values: {}, errors: formErrors };
+  };
+}


### PR DESCRIPTION
## Summary
- add public plan page with assignment table, bulk paste dialog, and submission flow
- introduce admin login page and server-side AdminGuard
- expose session cookie parser for server components

## Testing
- `npm run lint` *(fails: Failed to install required TypeScript dependencies)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b053c42c448329bf44167e74d5f3e0