### PR TITLE
Add admin dashboard and improve docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-MONGODB_URI=
+MONGODB_URI=mongodb+srv://username:password@cluster0.mongodb.net/?retryWrites=true&w=majority
 MONGODB_DB=amit-form
-NEXT_ADMIN_EMAIL=
-NEXT_ADMIN_PASSWORD=
-CRYPTO_TOKEN_SALT=
-SESSION_SECRET=
+NEXT_ADMIN_EMAIL=admin@example.com
+NEXT_ADMIN_PASSWORD=supersecret
+CRYPTO_TOKEN_SALT=change_me_long_random
+SESSION_SECRET=another_long_random_for_cookie_signing

--- a/README.md
+++ b/README.md
@@ -1,3 +1,73 @@
 # Amit Gardens
 
-Work in progress.
+A monthly scheduling application for managing gardeners and their assignments.
+
+## Setup
+
+### Requirements
+
+- Node.js 18+
+- MongoDB Atlas (or compatible) connection string
+
+### Installation
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env.local` and update the values.
+
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+4. On first run, visit [`/api/admin/init`](http://localhost:3000/api/admin/init) to create database indexes and seed demo data.
+
+### Build
+
+```bash
+npm run build
+npm start
+```
+
+## Deployment
+
+The project is designed for [Vercel](https://vercel.com/).
+
+Set the following environment variables in the deployment platform:
+
+- `MONGODB_URI`
+- `MONGODB_DB`
+- `NEXT_ADMIN_EMAIL`
+- `NEXT_ADMIN_PASSWORD`
+- `CRYPTO_TOKEN_SALT`
+- `SESSION_SECRET`
+
+After deploy, run `/api/admin/init` once to prepare the database.
+
+## Security Notes
+
+- Magic links are generated per gardener and stored as SHA-256 hashes using `CRYPTO_TOKEN_SALT`.
+- Admin login uses credentials from env variables and a signed session cookie (`SESSION_SECRET`).
+- Public routes implement basic rate limiting.
+- All API routes use Zod validators and normalized dates (midnight local time) to ensure consistency.
+
+## Development
+
+- TypeScript strict mode, ESLint and Prettier are configured.
+- Useful scripts:
+  - `npm run dev` – start dev server
+  - `npm run build` / `npm start` – build and run production
+  - `npm run lint` – run ESLint
+  - `npm run format` – format with Prettier
+
+## Features
+
+- Admin dashboard with KPIs, filtering and actions (CSV export, link creation, lock/unlock, reminders).
+- Per-gardener plan page with assignment editing and submission flow.
+- CSV export uses UTF‑8 with BOM for Hebrew compatibility.
+

--- a/app/admin/plan/[yyyymm]/dashboard-client.tsx
+++ b/app/admin/plan/[yyyymm]/dashboard-client.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import StatsCards from '@/components/StatsCards';
+import { useToast } from '@/components/ui/toaster';
+
+interface Stats {
+  gardeners: number;
+  submitted: number;
+  assignments: number;
+  coverageDays: number;
+}
+
+interface Row {
+  date: string;
+  gardener: string;
+  address: string;
+  notes: string;
+}
+
+interface LinkItem {
+  gardener_id: string;
+  url: string;
+  token: string;
+}
+
+export default function DashboardClient({ plan }: { plan: string }) {
+  const toast = useToast();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [rows, setRows] = useState<Row[]>([]);
+  const [locked, setLocked] = useState(false);
+  const [links, setLinks] = useState<LinkItem[]>([]);
+  const [filterGardener, setFilterGardener] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+
+  const load = async () => {
+    const res = await fetch(`/api/admin/overview?plan=${plan}`);
+    if (res.ok) {
+      const data = await res.json();
+      setStats(data.stats);
+      setRows(data.rows);
+      setLocked(!!data.locked);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, [plan]);
+
+  const createLinks = async () => {
+    const res = await fetch('/api/admin/links/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setLinks(data.links || []);
+      toast({ title: 'קישורים נוצרו' });
+    } else {
+      toast({ title: 'שגיאה ביצירת קישורים' });
+    }
+  };
+
+  const toggleLock = async () => {
+    const url = locked ? '/api/admin/unlock' : '/api/admin/lock';
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan }),
+    });
+    if (res.ok) {
+      setLocked(!locked);
+      toast({ title: locked ? 'נפתח' : 'ננעל' });
+    } else {
+      toast({ title: 'שגיאה' });
+    }
+  };
+
+  const sendReminders = async () => {
+    const res = await fetch('/api/admin/remind', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan }),
+    });
+    if (res.ok) {
+      toast({ title: 'תזכורות נשלחו' });
+    } else {
+      toast({ title: 'שגיאה בשליחת תזכורות' });
+    }
+  };
+
+  const gardenerOptions = Array.from(new Set(rows.map((r) => r.gardener))).filter(
+    Boolean,
+  );
+  const filtered = rows.filter((r) => {
+    if (filterGardener && r.gardener !== filterGardener) return false;
+    if (from && r.date < from) return false;
+    if (to && r.date > to) return false;
+    return true;
+  });
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold text-center">לוח מנהל {plan}</h1>
+      {stats && <StatsCards stats={stats} />}
+      <div className="flex flex-wrap gap-2">
+        <button onClick={createLinks} className="border px-2 py-1">
+          צור קישורים
+        </button>
+        <button onClick={toggleLock} className="border px-2 py-1">
+          {locked ? 'פתח' : 'נעל'}
+        </button>
+        <button onClick={sendReminders} className="border px-2 py-1">
+          שלח תזכורות
+        </button>
+        <a
+          href={`/api/admin/overview?plan=${plan}&format=csv`}
+          className="border px-2 py-1"
+        >
+          יצוא CSV
+        </a>
+      </div>
+      {links.length > 0 && (
+        <div className="border p-2 rounded-md">
+          <h2 className="font-semibold mb-1">קישורים שנוצרו</h2>
+          <ul className="list-disc pr-4 space-y-1">
+            {links.map((l) => (
+              <li key={l.gardener_id}>
+                <a href={l.url} className="underline" target="_blank">
+                  {l.url}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="space-y-2">
+        <div className="flex flex-wrap gap-2 items-center">
+          <select
+            value={filterGardener}
+            onChange={(e) => setFilterGardener(e.target.value)}
+            className="border p-1"
+          >
+            <option value="">כל הגננים</option>
+            {gardenerOptions.map((g) => (
+              <option key={g} value={g}>
+                {g}
+              </option>
+            ))}
+          </select>
+          <input
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="border p-1"
+          />
+          <input
+            type="date"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="border p-1"
+          />
+        </div>
+        <table className="w-full text-right border">
+          <thead>
+            <tr>
+              <th className="border p-1">תאריך</th>
+              <th className="border p-1">גנן</th>
+              <th className="border p-1">כתובת</th>
+              <th className="border p-1">הערות</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((r, idx) => (
+              <tr key={idx}>
+                <td className="border p-1">{r.date}</td>
+                <td className="border p-1">{r.gardener}</td>
+                <td className="border p-1">{r.address}</td>
+                <td className="border p-1">{r.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/plan/[yyyymm]/page.tsx
+++ b/app/admin/plan/[yyyymm]/page.tsx
@@ -1,0 +1,18 @@
+import AdminGuard from '@/components/AdminGuard';
+import DashboardClient from './dashboard-client';
+
+export default function AdminPlanPage({
+  params,
+}: {
+  params: { yyyymm: string };
+}) {
+  const { yyyymm } = params;
+  const plan = yyyymm.includes('-')
+    ? yyyymm
+    : `${yyyymm.slice(0, 4)}-${yyyymm.slice(4, 6)}`;
+  return (
+    <AdminGuard>
+      <DashboardClient plan={plan} />
+    </AdminGuard>
+  );
+}

--- a/app/api/admin/overview/route.ts
+++ b/app/api/admin/overview/route.ts
@@ -59,5 +59,6 @@ export async function GET(req: NextRequest) {
       coverageDays,
     },
     rows,
+    locked: planDoc.locked,
   });
 }

--- a/components/StatsCards.tsx
+++ b/components/StatsCards.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+interface Stats {
+  gardeners: number;
+  submitted: number;
+  assignments: number;
+  coverageDays: number;
+}
+
+export default function StatsCards({ stats }: { stats: Stats }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-center">
+      <div className="border p-4 rounded-md">
+        <p className="text-sm">גננים שהגישו</p>
+        <p className="text-xl font-bold">
+          {stats.submitted}/{stats.gardeners}
+        </p>
+      </div>
+      <div className="border p-4 rounded-md">
+        <p className="text-sm">שיבוצים</p>
+        <p className="text-xl font-bold">{stats.assignments}</p>
+      </div>
+      <div className="border p-4 rounded-md">
+        <p className="text-sm">ימי כיסוי</p>
+        <p className="text-xl font-bold">{stats.coverageDays}</p>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "autoprefixer": "^10.4.15",
     "postcss": "^8.4.27",
     "tailwindcss-rtl": "^0.9.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add admin plan dashboard with KPIs, filters, CSV export, link creation and lock/remind actions
- expose plan lock status from admin overview API
- document setup, env vars and deployment steps; add example env values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to install required TypeScript dependencies)*
- `npm run build` *(fails: Failed to fetch font `Alef`)*

------
https://chatgpt.com/codex/tasks/task_e_68b055b5d118832992043b55f62f9deb