### PR TITLE
feat: add worker dashboard and month grid

### DIFF
--- a/app/(public)/worker/page.tsx
+++ b/app/(public)/worker/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import dayjs from 'dayjs';
+import MonthGrid from '@/components/MonthGrid';
+
+type Status = 'not_started' | 'in_progress' | 'submitted';
+
+export default function WorkerDashboardPage() {
+  const search = useSearchParams();
+  const g = search.get('g') || '';
+  const t = search.get('t') || '';
+  const month = dayjs().add(1, 'month').format('YYYY-MM');
+  const [name, setName] = useState('');
+  const [status, setStatus] = useState<Status>('not_started');
+
+  useEffect(() => {
+    async function load() {
+      if (!g || !t) return;
+      const res = await fetch(`/api/link/resolve?plan=${month}&g=${g}&t=${t}`);
+      if (res.ok) {
+        const data = await res.json();
+        setName(data.gardener?.name || '');
+        if (data.submission) {
+          setStatus('submitted');
+          return;
+        }
+        const rowsRes = await fetch(`/api/assignments?plan=${month}&g=${g}&t=${t}`);
+        if (rowsRes.ok) {
+          const rows = await rowsRes.json();
+          setStatus(rows.assignments.length > 0 ? 'in_progress' : 'not_started');
+        }
+      }
+    }
+    load();
+  }, [g, t, month]);
+
+  const statusText: Record<Status, string> = {
+    not_started: 'לא התחלת',
+    in_progress: 'בתהליך',
+    submitted: 'הוגש',
+  };
+
+  const planLink = `/plan/${month}?g=${encodeURIComponent(g)}&t=${encodeURIComponent(t)}`;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">{`שלום${name ? ` ${name}` : ''}`}</h1>
+      <div className="card">
+        <div className="card-body text-center space-y-2">
+          <p>{`סטטוס לחודש ${month}: ${statusText[status]}`}</p>
+          <a href={planLink} className="btn btn-primary w-full">
+            ערוך את התוכנית
+          </a>
+        </div>
+      </div>
+      <MonthGrid month={month} />
+    </div>
+  );
+}

--- a/components/DayCell.tsx
+++ b/components/DayCell.tsx
@@ -1,0 +1,17 @@
+import type { FC } from 'react';
+
+interface DayCellProps {
+  /** ISO date string (YYYY-MM-DD) */
+  date: string;
+}
+
+const DayCell: FC<DayCellProps> = ({ date }) => {
+  const day = Number(date.slice(-2));
+  return (
+    <div className="border rounded-sm flex items-center justify-center aspect-square text-sm">
+      {day}
+    </div>
+  );
+};
+
+export default DayCell;

--- a/components/MonthGrid.tsx
+++ b/components/MonthGrid.tsx
@@ -1,0 +1,35 @@
+import dayjs from 'dayjs';
+import DayCell from './DayCell';
+
+const weekdays = ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ש'];
+
+interface MonthGridProps {
+  /** Month in YYYY-MM format */
+  month: string;
+}
+
+export default function MonthGrid({ month }: MonthGridProps) {
+  const start = dayjs(`${month}-01`);
+  const daysInMonth = start.daysInMonth();
+  const firstDay = start.day(); // Sunday = 0
+
+  const cells: Array<string | null> = [];
+  for (let i = 0; i < firstDay; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push(`${month}-${String(d).padStart(2, '0')}`);
+  }
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  return (
+    <div className="grid grid-cols-7 gap-1 text-center text-sm">
+      {weekdays.map((w) => (
+        <div key={w} className="font-medium py-1">
+          {w}
+        </div>
+      ))}
+      {cells.map((date, idx) =>
+        date ? <DayCell key={date} date={date} /> : <div key={idx} />,
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build MonthGrid and DayCell components to render monthly calendar
- add worker dashboard with greeting, status card, and calendar preview

## Testing
- `npm run lint` *(fails: 403 Forbidden retrieving @types/react)*
- `npx eslint components/MonthGrid.tsx components/DayCell.tsx app/(public)/worker/page.tsx && echo "lint ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b0a91adae083299471f4a61e3a6b84