### PR TITLE
Implement DayCell editor with bulk actions and submission review

### DIFF
--- a/app/(public)/plan/[yyyymm]/plan-client.tsx
+++ b/app/(public)/plan/[yyyymm]/plan-client.tsx
@@ -1,18 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useForm, useFieldArray } from 'react-hook-form';
-import { z } from 'zod';
-import { zodResolver } from '@/lib/zodResolver';
-import { AssignmentRowSchema } from '@/lib/validators';
-import AssignmentRow, { AssignmentFormRow } from '@/components/AssignmentRow';
-import BulkPasteDialog, { BulkRow } from '@/components/BulkPasteDialog';
+import dayjs from 'dayjs';
+import MonthGrid from '@/components/MonthGrid';
+import type { DayEntry } from '@/components/DayCell';
 import { useToast } from '@/components/ui/toaster';
 
-const RowSchema = AssignmentRowSchema.extend({ id: z.string().optional() });
-const FormSchema = z.object({ rows: z.array(RowSchema) });
-
-type FormData = z.infer<typeof FormSchema>;
+type AssignmentDto = {
+  date: string;
+  address: string;
+  notes: string | null;
+};
 
 interface Props {
   plan: string; // YYYY-MM
@@ -27,17 +25,13 @@ export default function PlanClient({ plan, g, t }: Props) {
     locked: boolean;
     submitted: boolean;
   } | null>(null);
+  const [entries, setEntries] = useState<Record<string, DayEntry>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const form = useForm<FormData>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: { rows: [] },
-  });
-  const { control, register, handleSubmit, reset } = form;
-  const { fields, append, remove } = useFieldArray({ control, name: 'rows' });
+  const [review, setReview] = useState(false);
 
   const readOnly = info?.locked || info?.submitted;
+  const storageKey = `draft:${plan}:${g}`;
 
   useEffect(() => {
     async function load() {
@@ -55,88 +49,84 @@ export default function PlanClient({ plan, g, t }: Props) {
         locked: data.plan.locked,
         submitted: !!data.submission,
       });
-      const resRows = await fetch(`/api/assignments?plan=${plan}&g=${g}&t=${t}`);
-      if (resRows.ok) {
-        type AssignmentRowDto = {
-          id: string;
-          date: string;
-          address: string;
-          notes: string | null;
-        };
-        const rows = (await resRows.json()) as { assignments: AssignmentRowDto[] };
-        reset({
-          rows: rows.assignments.map((r) => ({
-            id: r.id,
-            date: r.date.slice(0, 10),
+      const rowsRes = await fetch(`/api/assignments?plan=${plan}&g=${g}&t=${t}`);
+      if (rowsRes.ok) {
+        const { assignments } = await rowsRes.json();
+        const map: Record<string, DayEntry> = {};
+        (assignments as AssignmentDto[]).forEach((r) => {
+          map[r.date.slice(0, 10)] = {
             address: r.address,
             notes: r.notes || '',
-          })),
+          };
         });
+        setEntries(map);
+      }
+      const saved = typeof localStorage !== 'undefined' ? localStorage.getItem(storageKey) : null;
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved) as Record<string, DayEntry>;
+          setEntries((prev) => ({ ...prev, ...parsed }));
+        } catch {
+          /* ignore */
+        }
       }
       setLoading(false);
     }
     load();
-  }, [plan, g, t, reset]);
+  }, [plan, g, t, storageKey]);
 
-  const refreshRows = async () => {
-    const resRows = await fetch(`/api/assignments?plan=${plan}&g=${g}&t=${t}`);
-    if (resRows.ok) {
-      type AssignmentRowDto = {
-        id: string;
-        date: string;
-        address: string;
-        notes: string | null;
-      };
-      const rows = (await resRows.json()) as { assignments: AssignmentRowDto[] };
-      reset({
-        rows: rows.assignments.map((r) => ({
-          id: r.id,
-          date: r.date.slice(0, 10),
-          address: r.address,
-          notes: r.notes || '',
-        })),
-      });
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(storageKey, JSON.stringify(entries));
     }
+  }, [entries, storageKey]);
+
+  const onChange = (
+    date: string,
+    value: DayEntry | null,
+    bulk?: 'weekdays' | 'weekends' | 'all',
+  ) => {
+    setEntries((prev) => {
+      const next = { ...prev };
+      if (value) next[date] = value;
+      else delete next[date];
+      if (value && bulk) {
+        const start = dayjs(`${plan}-01`);
+        const daysInMonth = start.daysInMonth();
+        for (let d = 1; d <= daysInMonth; d++) {
+          const current = start.date(d);
+          const dow = current.day();
+          const ds = current.format('YYYY-MM-DD');
+          if (ds === date) continue;
+          if (
+            bulk === 'all' ||
+            (bulk === 'weekdays' && dow >= 0 && dow <= 4) ||
+            (bulk === 'weekends' && dow >= 5)
+          ) {
+            next[ds] = value;
+          }
+        }
+      }
+      return next;
+    });
   };
 
-  const onSave = handleSubmit(async (data) => {
-    const body = {
-      plan,
-      g,
-      t,
-      rows: data.rows.map((r) => ({
-        date: new Date(r.date).toISOString(),
-        address: r.address,
-        notes: r.notes,
-      })),
-    };
+  const onSave = async () => {
+    const rows = Object.entries(entries).map(([date, v]) => ({
+      date: new Date(date).toISOString(),
+      address: v.address,
+      notes: v.notes,
+    }));
     const res = await fetch('/api/assignments', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: JSON.stringify({ plan, g, t, rows }),
     });
     if (res.ok) {
       toast({ title: 'נשמר בהצלחה' });
-      await refreshRows();
     } else {
       toast({ title: 'שגיאה בשמירה' });
     }
-  });
-
-  const onDelete = async (idx: number, id?: string) => {
-    remove(idx);
-    if (id) {
-      await fetch(`/api/assignments/${id}?plan=${plan}&g=${g}&t=${t}`, {
-        method: 'DELETE',
-      });
-      await refreshRows();
-    }
-  };
-
-  const onPaste = (rows: BulkRow[]) => {
-    rows.forEach((r) =>
-      append({ date: r.date, address: r.address, notes: r.notes || '' }),
-    );
   };
 
   const submitFinal = async () => {
@@ -147,18 +137,24 @@ export default function PlanClient({ plan, g, t }: Props) {
     });
     if (res.ok) {
       toast({ title: 'הוגש' });
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(storageKey);
+      }
       setInfo((prev) => (prev ? { ...prev, submitted: true } : prev));
+      setReview(false);
     } else {
       toast({ title: 'שגיאה בשליחה' });
     }
   };
 
+  const filled = Object.keys(entries).length;
+  const required = 22;
+
   if (loading)
     return (
       <div className="p-4 space-y-4">
         <div className="skeleton h-6 w-1/2 mx-auto" />
-        <div className="skeleton h-9 w-full" />
-        <div className="skeleton h-40 w-full" />
+        <div className="skeleton h-60 w-full" />
       </div>
     );
   if (error) return <div className="p-4 empty-state">{error}</div>;
@@ -170,63 +166,57 @@ export default function PlanClient({ plan, g, t }: Props) {
           {`שיבוץ לחודש ${plan} – ${info.gardener}`}
         </h1>
       )}
-      <form onSubmit={onSave} className="space-y-3">
-        <div className="overflow-x-auto">
-          <table className="table table-zebra table-hover">
-            <thead>
-              <tr>
-                <th>תאריך</th>
-                <th>כתובת</th>
-                <th>הערות</th>
-                <th aria-label="פעולות" />
-              </tr>
-            </thead>
-            <tbody>
-              {fields.length === 0 ? (
-                <tr>
-                  <td colSpan={4} className="text-center py-8 text-muted-foreground">אין שורות עדיין</td>
-                </tr>
-              ) : (
-                fields.map((field, idx) => (
-                  <AssignmentRow
-                    key={field.id}
-                    index={idx}
-                    control={control}
-                    register={register}
-                    errors={form.formState.errors}
-                    onDelete={() => onDelete(idx, (field as AssignmentFormRow).id)}
-                    disabled={readOnly}
-                    month={plan}
-                  />
-                ))
-              )}
-            </tbody>
-          </table>
+      <div className="space-y-2">
+        <progress className="progress w-full" value={filled} max={required} />
+        <p className="text-center text-sm">{`${filled}/${required} ימים מלאים`}</p>
+      </div>
+      <MonthGrid month={plan} entries={entries} onChange={readOnly ? () => {} : onChange} />
+      {!readOnly && (
+        <div className="flex gap-2">
+          <button type="button" className="btn btn-secondary" onClick={onSave}>
+            שמור
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => setReview(true)}
+          >
+            שליחה סופית
+          </button>
         </div>
-        {!readOnly && (
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => append({ date: '', address: '', notes: '' })}
-              className="btn btn-secondary"
-            >
-              הוסף שורה
-            </button>
-            <BulkPasteDialog onConfirm={onPaste} />
-            <button type="submit" className="btn btn-primary">
-              שמור
-            </button>
-            <button
-              type="button"
-              onClick={submitFinal}
-              className="btn btn-ghost"
-            >
-              שליחה סופית
-            </button>
-          </div>
-        )}
-      </form>
+      )}
       {readOnly && <p className="text-center badge">הטופס נעול</p>}
+      {review && (
+        <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+          <div className="card w-full max-w-md">
+            <div className="card-header">אישור סופי</div>
+            <div className="card-body space-y-3 max-h-[60vh] overflow-y-auto">
+              <ul className="list-disc list-inside text-sm" dir="rtl">
+                {Object.entries(entries).map(([d, v]) => (
+                  <li key={d}>{`${d}: ${v.address}`}</li>
+                ))}
+              </ul>
+              <div className="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  className="btn btn-primary flex-1"
+                  onClick={submitFinal}
+                >
+                  שלח
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost flex-1"
+                  onClick={() => setReview(false)}
+                >
+                  בטל
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+

--- a/app/(public)/worker/page.tsx
+++ b/app/(public)/worker/page.tsx
@@ -55,7 +55,7 @@ export default function WorkerDashboardPage() {
           </a>
         </div>
       </div>
-      <MonthGrid month={month} />
+      <MonthGrid month={month} entries={{}} onChange={() => {}} />
     </div>
   );
 }

--- a/components/DayCell.tsx
+++ b/components/DayCell.tsx
@@ -1,17 +1,128 @@
+'use client';
+
 import type { FC } from 'react';
+import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
+
+export interface DayEntry {
+  address: string;
+  notes: string;
+}
 
 interface DayCellProps {
   /** ISO date string (YYYY-MM-DD) */
   date: string;
+  value?: DayEntry;
+  onChange: (
+    date: string,
+    value: DayEntry | null,
+    bulk?: 'weekdays' | 'weekends' | 'all',
+  ) => void;
 }
 
-const DayCell: FC<DayCellProps> = ({ date }) => {
+const DayCell: FC<DayCellProps> = ({ date, value, onChange }) => {
   const day = Number(date.slice(-2));
+  const [open, setOpen] = useState(false);
+  const [address, setAddress] = useState('');
+  const [notes, setNotes] = useState('');
+
+  useEffect(() => {
+    setAddress(value?.address ?? '');
+    setNotes(value?.notes ?? '');
+  }, [value, open]);
+
+  const save = (bulk?: 'weekdays' | 'weekends' | 'all') => {
+    const val = address || notes ? { address, notes } : null;
+    onChange(date, val, bulk);
+    setOpen(false);
+  };
+
+  const clear = () => {
+    setAddress('');
+    setNotes('');
+    onChange(date, null);
+    setOpen(false);
+  };
+
   return (
-    <div className="border rounded-sm flex items-center justify-center aspect-square text-sm">
-      {day}
-    </div>
+    <>
+      <button
+        type="button"
+        className={`border rounded-sm flex items-center justify-center aspect-square text-sm w-full h-full ${value ? 'bg-primary/20' : ''}`}
+        onClick={() => setOpen(true)}
+      >
+        {day}
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center">
+          <div className="bg-white w-full max-w-md p-4 rounded-t-lg space-y-3">
+            <h2 className="text-center font-medium">
+              {dayjs(date).format('DD/MM')}
+            </h2>
+            <input
+              type="text"
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="כתובת"
+              className="input w-full"
+            />
+            <input
+              type="text"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="הערות"
+              className="input w-full"
+            />
+            <div className="flex flex-wrap gap-2 pt-1">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => save()}
+              >
+                שמור
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => save('weekdays')}
+              >
+                לימי השבוע
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => save('weekends')}
+              >
+                לסופש
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => save('all')}
+              >
+                לכל החודש
+              </button>
+              <button
+                type="button"
+                className="btn btn-ghost"
+                onClick={clear}
+              >
+                מחק
+              </button>
+              <button
+                type="button"
+                className="btn btn-ghost"
+                onClick={() => setOpen(false)}
+              >
+                בטל
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 
 export default DayCell;
+

--- a/components/MonthGrid.tsx
+++ b/components/MonthGrid.tsx
@@ -1,14 +1,20 @@
 import dayjs from 'dayjs';
-import DayCell from './DayCell';
+import DayCell, { DayEntry } from './DayCell';
 
 const weekdays = ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ש'];
 
 interface MonthGridProps {
   /** Month in YYYY-MM format */
   month: string;
+  entries: Record<string, DayEntry>;
+  onChange: (
+    date: string,
+    value: DayEntry | null,
+    bulk?: 'weekdays' | 'weekends' | 'all',
+  ) => void;
 }
 
-export default function MonthGrid({ month }: MonthGridProps) {
+export default function MonthGrid({ month, entries, onChange }: MonthGridProps) {
   const start = dayjs(`${month}-01`);
   const daysInMonth = start.daysInMonth();
   const firstDay = start.day(); // Sunday = 0
@@ -28,7 +34,16 @@ export default function MonthGrid({ month }: MonthGridProps) {
         </div>
       ))}
       {cells.map((date, idx) =>
-        date ? <DayCell key={date} date={date} /> : <div key={idx} />,
+        date ? (
+          <DayCell
+            key={date}
+            date={date}
+            value={entries[date]}
+            onChange={onChange}
+          />
+        ) : (
+          <div key={idx} />
+        ),
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add interactive DayCell editor with bulk apply options
- enable MonthGrid to manage entries
- rebuild plan page with progress, bulk actions, and submission review

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npx eslint components/DayCell.tsx components/MonthGrid.tsx app/(public)/plan/[yyyymm]/plan-client.tsx app/(public)/worker/page.tsx`
- `npm run build` *(fails: Failed to fetch font `Alef`)*

------
https://chatgpt.com/codex/tasks/task_e_68b13015946c8329952444988f5f89f7