### PR TITLE
feat: add manager approvals dashboard

### DIFF
--- a/app/admin/approvals/[yyyymm]/[gardenerId]/detail-client.tsx
+++ b/app/admin/approvals/[yyyymm]/[gardenerId]/detail-client.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useToast } from '@/components/ui/toaster';
+
+interface Assignment {
+  date: string;
+  address: string;
+  notes: string;
+}
+
+interface DetailData {
+  gardener: { id: string; name: string; team: string };
+  status: 'pending' | 'approved' | 'needs_changes';
+  note: string;
+  assignments: Assignment[];
+}
+
+export default function DetailClient({ plan, gardenerId }: { plan: string; gardenerId: string }) {
+  const toast = useToast();
+  const router = useRouter();
+  const [data, setData] = useState<DetailData | null>(null);
+  const [note, setNote] = useState('');
+
+  const load = async () => {
+    const token = localStorage.getItem('admin_token') || '';
+    const res = await fetch(`/api/admin/submissions/detail?plan=${plan}&gardenerId=${gardenerId}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
+    if (res.ok) {
+      const json = await res.json();
+      setData(json);
+      setNote(json.note || '');
+    } else {
+      toast({ title: 'שגיאה בטעינה' });
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plan, gardenerId]);
+
+  const update = async (status: 'approved' | 'needs_changes') => {
+    const token = localStorage.getItem('admin_token') || '';
+    const res = await fetch('/api/admin/submissions/update', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ plan, gardenerId, status, note: status === 'needs_changes' ? note : undefined }),
+    });
+    if (res.ok) {
+      toast({ title: 'עודכן בהצלחה' });
+      router.back();
+    } else {
+      toast({ title: 'שגיאה בעדכון' });
+    }
+  };
+
+  if (!data) return <div className="p-4">טוען...</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-bold">{data.gardener.name}</h2>
+      <div className="overflow-x-auto">
+        <table className="table table-zebra">
+          <thead>
+            <tr>
+              <th>תאריך</th>
+              <th>כתובת</th>
+              <th>הערות</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.assignments.map((a, idx) => (
+              <tr key={idx}>
+                <td>{a.date}</td>
+                <td>{a.address}</td>
+                <td>{a.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="space-y-2">
+        <textarea
+          placeholder="הערות לבקשת שינוי"
+          className="textarea w-full"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <div className="flex gap-2">
+          <button onClick={() => update('approved')} className="btn btn-success flex-1">אשר הכל</button>
+          <button onClick={() => update('needs_changes')} className="btn btn-warning flex-1">בקש שינויים</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/approvals/[yyyymm]/[gardenerId]/page.tsx
+++ b/app/admin/approvals/[yyyymm]/[gardenerId]/page.tsx
@@ -1,0 +1,12 @@
+import AdminGuard from '@/components/AdminGuard';
+import DetailClient from './detail-client';
+
+export default function ApprovalDetailPage({ params }: { params: { yyyymm: string; gardenerId: string } }) {
+  const { yyyymm, gardenerId } = params;
+  const plan = yyyymm.includes('-') ? yyyymm : `${yyyymm.slice(0, 4)}-${yyyymm.slice(4, 6)}`;
+  return (
+    <AdminGuard>
+      <DetailClient plan={plan} gardenerId={gardenerId} />
+    </AdminGuard>
+  );
+}

--- a/app/admin/approvals/[yyyymm]/dashboard-client.tsx
+++ b/app/admin/approvals/[yyyymm]/dashboard-client.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useToast } from '@/components/ui/toaster';
+
+interface SubmissionItem {
+  gardenerId: string;
+  gardener: string;
+  team: string;
+  status: 'pending' | 'approved' | 'needs_changes';
+}
+
+export default function DashboardClient({ plan }: { plan: string }) {
+  const toast = useToast();
+  const [items, setItems] = useState<SubmissionItem[]>([]);
+  const [team, setTeam] = useState('');
+  const [worker, setWorker] = useState('');
+  const [status, setStatus] = useState('');
+
+  const load = async () => {
+    const token = localStorage.getItem('admin_token') || '';
+    const res = await fetch(`/api/admin/submissions/list?plan=${plan}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setItems(data.submissions || []);
+    } else {
+      toast({ title: 'שגיאה בטעינה' });
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plan]);
+
+  const teamOptions = Array.from(new Set(items.map((i) => i.team).filter(Boolean)));
+  const workerOptions = items
+    .filter((i) => !team || i.team === team)
+    .map((i) => ({ id: i.gardenerId, name: i.gardener }));
+  const filtered = items.filter((i) => {
+    if (team && i.team !== team) return false;
+    if (worker && i.gardener !== worker) return false;
+    if (status && i.status !== status) return false;
+    return true;
+  });
+
+  const statusBadge = (s: SubmissionItem['status']) => {
+    const map: Record<SubmissionItem['status'], { label: string; cls: string }> = {
+      pending: { label: 'ממתין', cls: 'badge-warning' },
+      approved: { label: 'מאושר', cls: 'badge-success' },
+      needs_changes: { label: 'דרוש שינוי', cls: 'badge-error' },
+    };
+    const { label, cls } = map[s];
+    return <span className={`badge ${cls}`}>{label}</span>;
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">אישורי מנהל {plan}</h1>
+      <div className="flex flex-wrap gap-2 items-center">
+        <select value={team} onChange={(e) => setTeam(e.target.value)} className="select h-8">
+          <option value="">כל הצוותים</option>
+          {teamOptions.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <select value={worker} onChange={(e) => setWorker(e.target.value)} className="select h-8">
+          <option value="">כל הגננים</option>
+          {workerOptions.map((w) => (
+            <option key={w.id} value={w.name}>{w.name}</option>
+          ))}
+        </select>
+        <select value={status} onChange={(e) => setStatus(e.target.value)} className="select h-8">
+          <option value="">כל הסטטוסים</option>
+          <option value="pending">ממתין</option>
+          <option value="approved">מאושר</option>
+          <option value="needs_changes">דרוש שינוי</option>
+        </select>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {filtered.map((item) => (
+          <div key={item.gardenerId} className="card">
+            <div className="card-body space-y-2">
+              <div className="flex justify-between items-center">
+                <h2 className="font-bold">{item.gardener}</h2>
+                {statusBadge(item.status)}
+              </div>
+              {item.team && <div className="text-sm text-muted-foreground">{item.team}</div>}
+              <Link href={`/admin/approvals/${plan}/${item.gardenerId}`} className="btn btn-primary w-full">פתח</Link>
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-center text-muted-foreground">אין נתונים</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/approvals/[yyyymm]/page.tsx
+++ b/app/admin/approvals/[yyyymm]/page.tsx
@@ -1,0 +1,12 @@
+import AdminGuard from '@/components/AdminGuard';
+import DashboardClient from './dashboard-client';
+
+export default function ApprovalsPage({ params }: { params: { yyyymm: string } }) {
+  const { yyyymm } = params;
+  const plan = yyyymm.includes('-') ? yyyymm : `${yyyymm.slice(0, 4)}-${yyyymm.slice(4, 6)}`;
+  return (
+    <AdminGuard>
+      <DashboardClient plan={plan} />
+    </AdminGuard>
+  );
+}

--- a/app/api/admin/submissions/detail/route.ts
+++ b/app/api/admin/submissions/detail/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AdminSubmissionDetailSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminFromAuthorization } from '@/lib/adminAuth';
+import { getPlanByYyyymm } from '@/lib/repositories/plans';
+import { listByPlanAndGardener } from '@/lib/repositories/assignments';
+import { getGardenerById } from '@/lib/repositories/gardeners';
+import { getStatus } from '@/lib/repositories/submissions';
+import { ObjectId } from 'mongodb';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = readAdminFromAuthorization(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  const params = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = AdminSubmissionDetailSchema.safeParse(params);
+  if (!parsed.success) return jsonError('invalid_query', 'Invalid query', 400);
+  const { plan, gardenerId } = parsed.data;
+  const yyyymm = plan.replace('-', '');
+  const planDoc = await getPlanByYyyymm(yyyymm);
+  if (!planDoc) return jsonError('not_found', 'Plan not found', 404);
+  const gid = new ObjectId(gardenerId);
+  const gardener = await getGardenerById(gid);
+  if (!gardener) return jsonError('not_found', 'Gardener not found', 404);
+  const assignments = await listByPlanAndGardener(planDoc._id, gid);
+  const submission = await getStatus(planDoc._id, gid);
+  return NextResponse.json({
+    gardener: { id: gardener._id.toString(), name: gardener.name, team: gardener.team || '' },
+    status: submission?.status || 'pending',
+    note: submission?.note || '',
+    assignments: assignments.map((a) => ({
+      date: a.work_date.toISOString().slice(0, 10),
+      address: a.address,
+      notes: a.notes || '',
+    })),
+  });
+}

--- a/app/api/admin/submissions/list/route.ts
+++ b/app/api/admin/submissions/list/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AdminSubmissionQuerySchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminFromAuthorization } from '@/lib/adminAuth';
+import { getPlanByYyyymm } from '@/lib/repositories/plans';
+import { listByPlan } from '@/lib/repositories/submissions';
+import { listGardeners } from '@/lib/repositories/gardeners';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = readAdminFromAuthorization(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  const params = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = AdminSubmissionQuerySchema.safeParse(params);
+  if (!parsed.success) return jsonError('invalid_query', 'Invalid query', 400);
+  const { plan } = parsed.data;
+  const yyyymm = plan.replace('-', '');
+  const planDoc = await getPlanByYyyymm(yyyymm);
+  if (!planDoc) return jsonError('not_found', 'Plan not found', 404);
+  const submissions = await listByPlan(planDoc._id);
+  const gardeners = await listGardeners();
+  const gardenerMap = new Map(gardeners.map((g) => [g._id.toString(), g]));
+  const result = submissions.map((s) => {
+    const g = gardenerMap.get(s.gardener_id.toString());
+    return {
+      gardenerId: s.gardener_id.toString(),
+      gardener: g?.name || '',
+      team: g?.team || '',
+      status: s.status || 'pending',
+      submitted_at: s.submitted_at,
+      note: s.note || '',
+    };
+  });
+  return NextResponse.json({ submissions: result });
+}

--- a/app/api/admin/submissions/update/route.ts
+++ b/app/api/admin/submissions/update/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AdminUpdateSubmissionSchema } from '@/lib/validators';
+import { jsonError } from '@/lib/api';
+import { readAdminFromAuthorization } from '@/lib/adminAuth';
+import { getPlanByYyyymm } from '@/lib/repositories/plans';
+import { updateStatus } from '@/lib/repositories/submissions';
+import { ObjectId } from 'mongodb';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const session = readAdminFromAuthorization(req);
+  if (!session) return jsonError('unauthorized', 'Unauthorized', 401);
+  const body = await req.json().catch(() => null);
+  const parsed = AdminUpdateSubmissionSchema.safeParse(body);
+  if (!parsed.success) return jsonError('invalid_body', 'Invalid request body', 400);
+  const { plan, gardenerId, status, note } = parsed.data;
+  const yyyymm = plan.replace('-', '');
+  const planDoc = await getPlanByYyyymm(yyyymm);
+  if (!planDoc) return jsonError('not_found', 'Plan not found', 404);
+  const gid = new ObjectId(gardenerId);
+  await updateStatus(planDoc._id, gid, status, note);
+  return NextResponse.json({ ok: true });
+}

--- a/lib/repositories/submissions.ts
+++ b/lib/repositories/submissions.ts
@@ -11,7 +11,15 @@ export async function submit(planId: ObjectId, gardenerId: ObjectId): Promise<vo
   const db = await getDb();
   await db.collection<Submission>('submissions').updateOne(
     { plan_id: planId, gardener_id: gardenerId },
-    { $set: { plan_id: planId, gardener_id: gardenerId, submitted_at: new Date() } },
+    {
+      $set: {
+        plan_id: planId,
+        gardener_id: gardenerId,
+        submitted_at: new Date(),
+        status: 'pending',
+      },
+      $unset: { note: '', reviewed_at: '' },
+    },
     { upsert: true },
   );
 }
@@ -19,4 +27,28 @@ export async function submit(planId: ObjectId, gardenerId: ObjectId): Promise<vo
 export async function revert(planId: ObjectId, gardenerId: ObjectId): Promise<void> {
   const db = await getDb();
   await db.collection<Submission>('submissions').deleteOne({ plan_id: planId, gardener_id: gardenerId });
+}
+
+export async function listByPlan(planId: ObjectId): Promise<Submission[]> {
+  const db = await getDb();
+  return db.collection<Submission>('submissions').find({ plan_id: planId }).toArray();
+}
+
+export async function updateStatus(
+  planId: ObjectId,
+  gardenerId: ObjectId,
+  status: 'approved' | 'needs_changes',
+  note?: string,
+): Promise<void> {
+  const db = await getDb();
+  await db.collection<Submission>('submissions').updateOne(
+    { plan_id: planId, gardener_id: gardenerId },
+    {
+      $set: {
+        status,
+        note,
+        reviewed_at: new Date(),
+      },
+    },
+  );
 }

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -49,3 +49,19 @@ export const AdminAuthSchema = z.object({
   password: z.string().min(8),
 });
 
+export const AdminSubmissionQuerySchema = z.object({
+  plan: z.string().regex(planRegex),
+});
+
+export const AdminSubmissionDetailSchema = z.object({
+  plan: z.string().regex(planRegex),
+  gardenerId: z.string(),
+});
+
+export const AdminUpdateSubmissionSchema = z.object({
+  plan: z.string().regex(planRegex),
+  gardenerId: z.string(),
+  status: z.enum(['approved', 'needs_changes']),
+  note: z.string().optional(),
+});
+

--- a/types/db.ts
+++ b/types/db.ts
@@ -4,6 +4,7 @@ export interface Gardener {
   _id: ObjectId;
   name: string;
   phone?: string;
+  team?: string;
   created_at: Date;
 }
 
@@ -39,4 +40,7 @@ export interface Submission {
   plan_id: ObjectId;
   gardener_id: ObjectId;
   submitted_at: Date;
+  status: 'pending' | 'approved' | 'needs_changes';
+  note?: string;
+  reviewed_at?: Date;
 }


### PR DESCRIPTION
## Summary
- extend submission model with status, note, and review timestamps
- add admin API routes for listing, viewing, and updating submissions
- implement manager dashboard and detail pages with filters and approval actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: unused vars and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68b13192d614832991a374da8f64823e