### PR TITLE
feat: polish ui with tokens animations empty states

### DIFF
--- a/app/admin/approvals/[yyyymm]/dashboard-client.tsx
+++ b/app/admin/approvals/[yyyymm]/dashboard-client.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useToast } from '@/components/ui/toaster';
+import EmptyState from '@/components/EmptyState';
+import { Inbox } from 'lucide-react';
 
 interface SubmissionItem {
   gardenerId: string;
@@ -81,6 +83,9 @@ export default function DashboardClient({ plan }: { plan: string }) {
         </select>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
+        {filtered.length === 0 && (
+          <EmptyState icon={<Inbox className="h-10 w-10" />} title="אין נתונים" />
+        )}
         {filtered.map((item) => (
           <div key={item.gardenerId} className="card">
             <div className="card-body space-y-2">
@@ -93,9 +98,6 @@ export default function DashboardClient({ plan }: { plan: string }) {
             </div>
           </div>
         ))}
-        {filtered.length === 0 && (
-          <p className="text-center text-muted-foreground">אין נתונים</p>
-        )}
       </div>
     </div>
   );

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@/lib/zodResolver';
@@ -9,11 +8,11 @@ import dayjs from 'dayjs';
 import { AdminAuthSchema } from '@/lib/validators';
 import { useToast } from '@/components/ui/toaster';
 import { useState as useReactState } from 'react';
+import { motion as motionTokens } from '@/lib/tokens';
 
 type FormData = z.infer<typeof AdminAuthSchema>;
 
 export default function AdminLoginPage() {
-  const router = useRouter();
   const toast = useToast();
   const [serverError, setServerError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useReactState(false);
@@ -45,7 +44,10 @@ export default function AdminLoginPage() {
   };
 
   return (
-    <div className="container max-w-md mx-auto p-6">
+    <div
+      className="container max-w-md mx-auto p-6 animate-fade-in"
+      style={{ animationDuration: motionTokens.normal }}
+    >
       <div className="card">
         <div className="card-header text-center">התחברות מנהל</div>
         <div className="card-body">

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,6 +21,9 @@
     --destructive-foreground: 210 40% 98%;
     --input: 214.3 31.8% 91.4%;
     --ring: 221.2 83.2% 53.3%;
+    --motion-fast: 150ms;
+    --motion-normal: 300ms;
+    --motion-slow: 500ms;
   }
 
   .dark {
@@ -41,6 +44,9 @@
     --destructive-foreground: 210 40% 98%;
     --input: 217.2 32.6% 17.5%;
     --ring: 224.3 76.3% 48%;
+    --motion-fast: 150ms;
+    --motion-normal: 300ms;
+    --motion-slow: 500ms;
   }
 
   * {
@@ -129,4 +135,30 @@
   .skeleton {
     @apply animate-pulse rounded-md bg-muted;
   }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in var(--motion-normal) ease-out forwards;
+}
+
+.animate-slide-up {
+  animation: slide-up var(--motion-normal) ease-out forwards;
 }

--- a/components/DayCell.tsx
+++ b/components/DayCell.tsx
@@ -2,6 +2,7 @@
 
 import type { FC } from 'react';
 import { useState, useEffect } from 'react';
+import { motion as motionTokens } from '@/lib/tokens';
 import dayjs from 'dayjs';
 
 export interface DayEntry {
@@ -54,8 +55,14 @@ const DayCell: FC<DayCellProps> = ({ date, value, onChange }) => {
         {day}
       </button>
       {open && (
-        <div className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center">
-          <div className="bg-white w-full max-w-md p-4 rounded-t-lg space-y-3">
+        <div
+          className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center animate-fade-in"
+          style={{ animationDuration: motionTokens.normal }}
+        >
+          <div
+            className="bg-white w-full max-w-md p-4 rounded-t-lg space-y-3 animate-slide-up"
+            style={{ animationDuration: motionTokens.normal }}
+          >
             <h2 className="text-center font-medium">
               {dayjs(date).format('DD/MM')}
             </h2>

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  title: string;
+  icon?: ReactNode;
+  action?: ReactNode;
+}
+
+export default function EmptyState({ title, icon, action }: EmptyStateProps) {
+  return (
+    <div className="empty-state">
+      {icon && <div className="mb-2 text-muted-foreground">{icon}</div>}
+      <p>{title}</p>
+      {action}
+    </div>
+  );
+}

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,0 +1,27 @@
+export const tokens = {
+  colors: {
+    gradientFrom: '#3b82f6',
+    gradientTo: '#8b5cf6',
+    success: '#16a34a',
+    warning: '#f59e0b',
+    destructive: '#dc2626',
+  },
+  typography: {
+    fontFamily: "var(--font-sans), system-ui, sans-serif",
+    body: '14px',
+  },
+  radii: {
+    sm: '6px',
+    md: '10px',
+    lg: '14px',
+    xl: '20px',
+  },
+  motion: {
+    fast: '150ms',
+    normal: '300ms',
+    slow: '500ms',
+  },
+};
+
+export type Tokens = typeof tokens;
+export const motion = tokens.motion;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { tokens } from "./lib/tokens";
 
 const config: Config = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
@@ -39,11 +40,11 @@ const config: Config = {
         ring: "hsl(var(--ring))",
       },
       borderRadius: {
-        sm: "6px",
-        DEFAULT: "10px",
-        md: "10px",
-        lg: "14px",
-        xl: "20px",
+        sm: tokens.radii.sm,
+        DEFAULT: tokens.radii.md,
+        md: tokens.radii.md,
+        lg: tokens.radii.lg,
+        xl: tokens.radii.xl,
       },
       boxShadow: {
         sm: "0 1px 2px 0 rgba(16, 24, 40, 0.06)",


### PR DESCRIPTION
## Summary
- add design tokens for colors, radii, motion
- animate day editor and login with new motion utilities
- introduce EmptyState component and use it in approvals view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: createLinks is assigned a value but never used, etc.)
- `npm run build` (fails: Failed to fetch Alef from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68b132daeacc8329a3cfeba985f4e7fc